### PR TITLE
Rename Go module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 output/*.csv
 dist/*
 .vscode/*
+.idea/*
 
 experiments/*
 defenderharvester*

--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ More information in this blog post; [Microsoft Defender for Endpoint Internals 0
 **NOTE:**
 All data is collected from the MDE Service API, and is not supported by Microsoft. Use at your own risk.
 
-# Getting Started
+# Installation
 
 Make sure to have the following installed:
 - [Azure Cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+
+Defender Harvester is published through [releases](https://github.com/olafhartong/DefenderHarvester/releases/latest) or can be installed through Go:
+```bash
+go install github.com/olafhartong/defenderharvester@latest
+```
+
+# Getting Started
 
 Log in to Azure with an account that has access to M365D / MDE:
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module defenderharvester
+module github.com/olafhartong/defenderharvester
 
 go 1.21.1
 

--- a/main.go
+++ b/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"defenderharvester/cmd"
 	"flag"
 	"fmt"
+	"github.com/olafhartong/defenderharvester/cmd"
 	"log"
 	"net/url"
 	"strings"


### PR DESCRIPTION
Renamed the Go module to allow installation through `go install`.

Without renaming the module, installation fails given the module name & URL mismatches.
```shell
PS C:\Users\user> go install github.com/olafhartong/DefenderHarvester@latest
go: downloading github.com/olafhartong/DefenderHarvester v0.9.8
go: github.com/olafhartong/DefenderHarvester@latest: version constraints conflict:
        github.com/olafhartong/DefenderHarvester@v0.9.8: parsing go.mod:
        module declares its path as: defenderharvester
                but was required as: github.com/olafhartong/DefenderHarvester
```